### PR TITLE
Fix refs to dump1090-fa

### DIFF
--- a/bash/decoders/dump1090-mutability.sh
+++ b/bash/decoders/dump1090-mutability.sh
@@ -224,7 +224,7 @@ if [[ "${RECEIVER_AUTOMATED_INSTALL}" = "false" ]] ; then
 fi
 if [[ -n "${DUMP1090_BING_MAPS_KEY}" ]] ; then
     echo -e "\e[94m  Setting the Bing Maps API Key to ${DUMP1090_BING_MAPS_KEY}...\e[97m"
-    ChangeConfig "BingMapsAPIKey" "${DUMP1090_BING_MAPS_KEY}" "/usr/share/dump1090-fa/html/config.js"
+    ChangeConfig "BingMapsAPIKey" "${DUMP1090_BING_MAPS_KEY}" "/usr/share/dump1090-mutability/html/config.js"
 fi
 
 # Ask for a Mapzen API key.
@@ -233,7 +233,7 @@ if [[ "${RECEIVER_AUTOMATED_INSTALL}" = "false" ]] ; then
 fi
 if [[ -n "${DUMP1090_MAPZEN_KEY}" ]] ; then
     echo -e "\e[94m  Setting the Mapzen API Key to ${DUMP1090_MAPZEN_KEY}...\e[97m"
-    ChangeConfig "MapzenAPIKey" "${DUMP1090_MAPZEN_KEY}" "/usr/share/dump1090-fa/html/config.js"
+    ChangeConfig "MapzenAPIKey" "${DUMP1090_MAPZEN_KEY}" "/usr/share/dump1090-mutability/html/config.js"
 fi
 
 # Ask if dump1090-mutability should bind on all IP addresses.
@@ -289,13 +289,13 @@ else
 fi
 
 # Download Heywhatsthat.com maximum range rings.
-if [[ ! -f "/usr/share/dump1090-fa/html/upintheair.json" ]] ; then
+if [[ ! -f "/usr/share/dump1090-mutability/html/upintheair.json" ]] ; then
     if [[ "${RECEIVER_AUTOMATED_INSTALL}" = "false" ]] ; then
         if (whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" --title "Heywhaststhat.com Maximum Range Rings" --yesno "Maximum range rings can be added to dump1090-fa usings data obtained from Heywhatsthat.com. In order to add these rings to your dump1090-fa map you will first need to visit http://www.heywhatsthat.com and generate a new panorama centered on the location of your receiver. Once your panorama has been generated a link to the panorama will be displayed in the top left hand portion of the page. You will need the view id which is the series of letters and/or numbers after \"?view=\" in this URL.\n\nWould you like to add heywatsthat.com maximum range rings to your map?" 16 78) ; then
             # Set the DUMP1090_HEYWHATSTHAT_INSTALL variable to true.
             DUMP1090_HEYWHATSTHAT_INSTALL="true"
             # Ask the user for the Heywhatsthat.com panorama ID.
-            DUMP1090_HEYWHATSTHAT_ID_TITLE="Heywhatsthat.com Panarama ID"
+            DUMP1090_HEYWHATSTHAT_ID_TITLE="Heywhatsthat.com Panorama ID"
             while [[ -z "${DUMP1090_HEYWHATSTHAT_ID}" ]] ; do
                 DUMP1090_HEYWHATSTHAT_ID=$(whiptail --backtitle "${RECEIVER_PROJECT_TITLE}" --title "${DUMP1090_HEYWHATSTHAT_ID_TITLE}" --nocancel --inputbox "\nEnter your Heywhatsthat.com panorama ID." 8 78 3>&1 1>&2 2>&3)
                 DUMP1090_HEYWHATSTHAT_ID_TITLE="Heywhatsthat.com Panarama ID (REQUIRED)"
@@ -318,7 +318,7 @@ if [[ ! -f "/usr/share/dump1090-fa/html/upintheair.json" ]] ; then
     if [[ "${DUMP1090_HEYWHATSTHAT_INSTALL}" = "true" ]] ; then
         echo -e "\e[94m  Downloading JSON data pertaining to the supplied panorama ID...\e[97m"
         echo -e ""
-        sudo wget -O /usr/share/dump1090-fa/html/upintheair.json "http://www.heywhatsthat.com/api/upintheair.json?id=${DUMP1090_HEYWHATSTHAT_ID}&refraction=0.25&alts=${DUMP1090_HEYWHATSTHAT_RING_ONE},${DUMP1090_HEYWHATSTHAT_RING_TWO}"
+        sudo wget -O /usr/share/dump1090-mutability/html/upintheair.json "http://www.heywhatsthat.com/api/upintheair.json?id=${DUMP1090_HEYWHATSTHAT_ID}&refraction=0.25&alts=${DUMP1090_HEYWHATSTHAT_RING_ONE},${DUMP1090_HEYWHATSTHAT_RING_TWO}"
     fi
 fi
 


### PR DESCRIPTION
Fixes references to the Dump1090-FA config files for map keys and the UpInTheAir panorama.